### PR TITLE
Improve Remove Knot Test

### DIFF
--- a/Sources/ParameterSpaces/knot_vector.cpp
+++ b/Sources/ParameterSpaces/knot_vector.cpp
@@ -176,7 +176,7 @@ void KnotVector::Insert(Knot_ knot, Multiplicity const &multiplicity, Tolerance 
   knots_.insert(knots_.begin() + FindSpan(knot, tolerance).Get() + 1, multiplicity.Get(), move(knot));
 }
 
-void KnotVector::Remove(Knot_ const &knot, Multiplicity const &multiplicity, Tolerance const &tolerance) {
+Multiplicity KnotVector::Remove(Knot_ const &knot, Multiplicity const &multiplicity, Tolerance const &tolerance) {
 #ifndef NDEBUG
   Message const kName{"splinelib::sources::parameter_spaces::KnotVector::Remove"};
 
@@ -186,9 +186,8 @@ void KnotVector::Remove(Knot_ const &knot, Multiplicity const &multiplicity, Tol
   } catch (DomainError const &exception) { Throw(exception, kName); }
     catch (InvalidArgument const &exception) { Throw(exception, kName); }
 #endif
-  Multiplicity::Type_ const number_of_removals{std::min(multiplicity.Get(), DetermineMultiplicity(knot,
-                                                                                                  tolerance).Get())};
-  if (number_of_removals != 0) {
+  if (Multiplicity::Type_ const number_of_removals{std::min(multiplicity,
+          DetermineMultiplicity(knot, tolerance)).Get()}; number_of_removals != 0) {
     KnotSpan const &knot_span = FindSpan(knot, tolerance);
     if (DoesParametricCoordinateEqualBack(knot, tolerance)) {
       ConstIterator_ const &end = knots_.end();
@@ -197,6 +196,9 @@ void KnotVector::Remove(Knot_ const &knot, Multiplicity const &multiplicity, Tol
       ConstIterator_ const &first_knot = (knots_.begin() + knot_span.Get());
       knots_.erase(first_knot - (number_of_removals - 1), first_knot + 1);
     }
+    return Multiplicity{number_of_removals};
+  } else {
+    return Multiplicity{};
   }
 }
 

--- a/Sources/ParameterSpaces/knot_vector.hpp
+++ b/Sources/ParameterSpaces/knot_vector.hpp
@@ -73,8 +73,8 @@ class KnotVector {
 
   virtual void Insert(Knot_ knot, Multiplicity const &multiplicity = kMultiplicity,
                       Tolerance const &tolerance = kEpsilon);
-  virtual void Remove(Knot_ const &knot, Multiplicity const &multiplicity = kMultiplicity,
-                      Tolerance const &tolerance = kEpsilon);
+  virtual Multiplicity Remove(Knot_ const &knot, Multiplicity const &multiplicity = kMultiplicity,
+                              Tolerance const &tolerance = kEpsilon);
   virtual void IncreaseMultiplicities(Multiplicity const &multiplicity = kMultiplicity,
                                       Tolerance const &tolerance = kEpsilon);
   virtual void DecreaseMultiplicities(Multiplicity const &multiplicity = kMultiplicity,

--- a/Sources/ParameterSpaces/parameter_space.inc
+++ b/Sources/ParameterSpaces/parameter_space.inc
@@ -249,11 +249,13 @@ ParameterSpace<parametric_dimensionality>::RemoveKnot(Dimension const &dimension
     catch (OutOfRange const &exception) { Throw(exception, kName, dimension_value); }
     catch (InvalidArgument const &exception) { Throw(exception, kName, dimension_value); }
 #endif
-  KnotVector &knot_vector = *knot_vectors_[dimension_value];
-  MultiplicityType_ const &removals = knot_vector.GetSize();
-  knot_vector.Remove(knot, multiplicity, tolerance);
-  RecreateBasisFunctions(tolerance);
-  return DetermineInsertionInformation(dimension, knot, Multiplicity{removals - knot_vector.GetSize()}, tolerance);
+  if (Multiplicity const &removals = knot_vectors_[dimension_value]->Remove(knot, multiplicity, tolerance);
+      removals != Multiplicity{}) {
+    RecreateBasisFunctions(tolerance);
+    return DetermineInsertionInformation(dimension, knot, removals, tolerance);
+  } else {
+    return InsertionInformation_{};
+  }
 }
 
 // Cf. NURBS book Eq. (5.36).

--- a/Sources/Splines/b_spline.inc
+++ b/Sources/Splines/b_spline.inc
@@ -180,10 +180,10 @@ Multiplicity BSpline<parametric_dimensionality, dimensionality>::RemoveKnot(Dime
   IndexLength_ number_of_coordinates{parameter_space.GetNumberOfBasisFunctions()};
   auto const &[start_value, coefficients] = parameter_space.RemoveKnot(dimension, knot, multiplicity, tolerance);
   Multiplicity::Type_ const &removals = coefficients.size();
-  for (Multiplicity removal{removals - 1}; removal >= Multiplicity{}; --removal) {
+  for (Multiplicity removal{removals}; removal > Multiplicity{}; --removal) {
     VectorSpace_ &vector_space = *vector_space_;
     VectorSpace_ const vector_space_backup{vector_space};
-    KnotRatios_ const &current_coefficients = coefficients[removal.Get()];
+    KnotRatios_ const &current_coefficients = coefficients[removal.Get() - 1];
     IndexLength_ number_of_coordinates_in_slice{number_of_coordinates};
     number_of_coordinates_in_slice[dimension_value] = Length{};
     IndexLength_ const previous_number_of_coordinates{number_of_coordinates};
@@ -214,7 +214,7 @@ Multiplicity BSpline<parametric_dimensionality, dimensionality>::RemoveKnot(Dime
                           Coordinate{tolerance_removal})) {
         vector_space.Erase(coordinate_index);
       } else {
-        Multiplicity const &successful_removals = (multiplicity - ++removal);
+        Multiplicity const &successful_removals = (multiplicity - removal);
         parameter_space_backup.RemoveKnot(dimension, knot, successful_removals, tolerance);
         parameter_space = parameter_space_backup;
         vector_space = vector_space_backup;

--- a/Tests/ParameterSpaces/b_spline_basis_function_mock.cpp
+++ b/Tests/ParameterSpaces/b_spline_basis_function_mock.cpp
@@ -545,21 +545,45 @@ BSplineBasisFunctions NurbsBookExe3_8() {
   return basis_functions;
 }
 
+BSplineBasisFunctions NurbsBookExe3_8InsertRemove() {
+  BSplineBasisFunctions basis_functions;
+  BSplineBasisFunctionsDimension &basis_functions_0 = basis_functions[0], &basis_functions_1 = basis_functions[1];
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function0_2{
+                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
+  basis_function0_2->NurbsBookExe3_8_0_0_2();
+  basis_functions_0.push_back(basis_function0_2);
+  basis_functions_1.push_back(basis_function0_2);
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function1_2{
+                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
+  basis_function1_2->NurbsBookExe3_8_0_1_2();
+  basis_functions_0.push_back(basis_function1_2);
+  basis_functions_1.push_back(basis_function1_2);
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function2_2{
+                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
+  basis_function2_2->NurbsBookExe3_8_0_2_2();
+  basis_functions_0.push_back(basis_function2_2);
+  basis_functions_1.push_back(basis_function2_2);
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function3_2{
+                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
+  basis_function3_2->NurbsBookExe3_8_0_3_2();
+  basis_functions_0.push_back(basis_function3_2);
+  basis_functions_1.push_back(basis_function3_2);
+  return basis_functions;
+}
+
 BSplineBasisFunctions NurbsBookExe4_4() {
   BSplineBasisFunctions basis_functions;
   BSplineBasisFunctionsDimension &basis_functions_0 = basis_functions[0], &basis_functions_1 = basis_functions[1];
-  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function0_0_1{
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function0_1{
                                                        make_shared<NonZeroDegreeBSplineBasisFunction>()};
-  basis_function0_0_1->NurbsBookExa2_1_1_1(); basis_functions_0.push_back(basis_function0_0_1);
-  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function0_1_1{
+  basis_function0_1->NurbsBookExa2_1_1_1();
+  basis_functions_0.push_back(basis_function0_1);
+  basis_functions_1.push_back(basis_function0_1);
+  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function1_1{
                                                        make_shared<NonZeroDegreeBSplineBasisFunction>()};
-  basis_function0_1_1->NurbsBookExa2_1_2_1(); basis_functions_0.push_back(basis_function0_1_1);
-  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function1_0_1{
-                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
-  basis_function1_0_1->NurbsBookExa2_1_1_1(); basis_functions_1.push_back(basis_function1_0_1);
-  SharedPointer<NonZeroDegreeBSplineBasisFunction> basis_function1_1_1{
-                                                       make_shared<NonZeroDegreeBSplineBasisFunction>()};
-  basis_function1_1_1->NurbsBookExa2_1_2_1(); basis_functions_1.push_back(basis_function1_1_1);
+  basis_function1_1->NurbsBookExa2_1_2_1();
+  basis_functions_0.push_back(basis_function1_1);
+  basis_functions_1.push_back(basis_function1_1);
   return basis_functions;
 }
 

--- a/Tests/ParameterSpaces/b_spline_basis_function_mock.hpp
+++ b/Tests/ParameterSpaces/b_spline_basis_function_mock.hpp
@@ -124,6 +124,7 @@ BSplineBasisFunctions NurbsBookExa2_2ElevatedOnce();
 BSplineBasisFunctions NurbsBookExa2_2Inserted();
 BSplineBasisFunctions NurbsBookExa2_2Subdivided();
 BSplineBasisFunctions NurbsBookExe3_8();
+BSplineBasisFunctions NurbsBookExe3_8InsertRemove();
 BSplineBasisFunctions NurbsBookExe4_4();
 
 }  // namespace mock_b_spline_basis_functions

--- a/Tests/ParameterSpaces/knot_vector_mock.cpp
+++ b/Tests/ParameterSpaces/knot_vector_mock.cpp
@@ -26,8 +26,8 @@ MATCHER_P2(IsGeAndLt, minimum, supremum, "") {
 }
 
 using Knots = AKnotVectorMock::Knots_;
-using sources::utilities::string_operations::Write, testing::AtMost, testing::Ge, testing::InvokeWithoutArgs,
-      testing::Return, testing::ReturnRef;
+using sources::utilities::string_operations::Write, testing::AtMost, testing::DoAll, testing::Ge,
+      testing::InvokeWithoutArgs, testing::Return, testing::ReturnRef;
 
 constexpr Index const kIndex0{}, kIndex1{1}, kIndex2{2}, kIndex3{3}, kIndex4{4}, kIndex5{5}, kIndex6{6}, kIndex7{7},
                       kIndex8{8}, kIndex9{9}, kIndex10{10}, kIndex11{11}, kIndex12{12}, kIndex13{13}, kIndex14{14},
@@ -82,9 +82,9 @@ void AKnotVectorMock::Insert(ParametricCoordinate knot, Multiplicity const &mult
   InsertMock(knot, multiplicity, tolerance);
 }
 
-void AKnotVectorMock::Remove(ParametricCoordinate const &parametric_coordinate, Multiplicity const &multiplicity,
-    Tolerance_ const &tolerance) {
-  RemoveMock(parametric_coordinate, multiplicity, tolerance);
+Multiplicity AKnotVectorMock::Remove(ParametricCoordinate const &parametric_coordinate,
+                                     Multiplicity const &multiplicity, Tolerance_ const &tolerance) {
+  return RemoveMock(parametric_coordinate, multiplicity, tolerance);
 }
 
 void AKnotVectorMock::IncreaseMultiplicities(Multiplicity const &multiplicity, Tolerance_ const &tolerance) {
@@ -134,6 +134,7 @@ void AKnotVectorMock::NurbsBookExa2_1() {
       .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExe3_8_0));
   EXPECT_CALL(*this, InsertMock(k0_5, kMultiplicity2, IsGe0_0AndLt0_5)).Times(AtMost(1))
       .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExe3_8_0Subdivided));
+  EXPECT_CALL(*this, RemoveMock(k0_5, kMultiplicity_, IsGe0_0AndLt1_0)).WillRepeatedly(Return(kMultiplicity0));
 
   EXPECT_CALL(*this, WriteMock(kPrecision_)).WillRepeatedly(Return(OutputInformation_{kZero, kZero, kZero, kOne, kOne,
                                                                                       kOne}));
@@ -433,7 +434,7 @@ void AKnotVectorMock::NurbsBookExe3_8_0() {
   EXPECT_CALL(*this, InsertMock(k0_5, kMultiplicity_, IsGe0_0AndLt0_5)).Times(AtMost(1))
       .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExe3_8_0Subdivided));
   EXPECT_CALL(*this, RemoveMock(k0_5, kMultiplicity_, IsGe0_0AndLt0_5)).Times(AtMost(1))
-      .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExa2_1));
+      .WillOnce(DoAll(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExa2_1), Return(kMultiplicity_)));
 
   EXPECT_CALL(*this, WriteMock(kPrecision_)).WillRepeatedly(Return(OutputInformation_{kZero, kZero,
                                                  sources::utilities::string_operations::Write(k0_5), kOne, kOne}));
@@ -473,9 +474,9 @@ void AKnotVectorMock::NurbsBookExe3_8_0Subdivided() {
   EXPECT_CALL(*this, GetUniqueKnotsMock(IsGe0_0AndLt0_5)).WillRepeatedly(Return(kUniqueKnots3_8));
 
   EXPECT_CALL(*this, RemoveMock(k0_5, kMultiplicity_, IsGe0_0AndLt0_5)).Times(AtMost(1))
-      .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExe3_8_0));
+      .WillOnce(DoAll(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExe3_8_0), Return(kMultiplicity_)));
   EXPECT_CALL(*this, RemoveMock(k0_5, kMultiplicity2, IsGe0_0AndLt0_5)).Times(AtMost(1))
-      .WillOnce(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExa2_1));
+      .WillOnce(DoAll(InvokeWithoutArgs(this, &AKnotVectorMock::NurbsBookExa2_1), Return(kMultiplicity2)));
 }
 
 void AKnotVectorMock::NurbsBookExe4_4() {

--- a/Tests/ParameterSpaces/knot_vector_mock.hpp
+++ b/Tests/ParameterSpaces/knot_vector_mock.hpp
@@ -55,9 +55,9 @@ class AKnotVectorMock : public sources::parameter_spaces::KnotVector {
   MOCK_METHOD(void, InsertMock, (ParametricCoordinate, Multiplicity const &, Tolerance_ const &), (const));
   void Insert(ParametricCoordinate knot, Multiplicity const &multiplicity, Tolerance_ const &tolerance = kEpsilon_)
       final;
-  MOCK_METHOD(void, RemoveMock, (ParametricCoordinate const &, Multiplicity const &, Tolerance_ const &), ());
-  void Remove(ParametricCoordinate const &knot, Multiplicity const &multiplicity = kMultiplicity_,
-              Tolerance_ const &tolerance = kEpsilon_) final;
+  MOCK_METHOD(Multiplicity, RemoveMock, (ParametricCoordinate const &, Multiplicity const &, Tolerance_ const &), ());
+  Multiplicity Remove(ParametricCoordinate const &knot, Multiplicity const &multiplicity = kMultiplicity_,
+                      Tolerance_ const &tolerance = kEpsilon_) final;
   MOCK_METHOD(void, IncreaseMultiplicitiesMock, (Multiplicity const &, Tolerance_ const &), ());
   void IncreaseMultiplicities(Multiplicity const &multiplicity = kMultiplicity_,
                               Tolerance_ const &tolerance = kEpsilon_) final;

--- a/Tests/ParameterSpaces/knot_vector_test.cpp
+++ b/Tests/ParameterSpaces/knot_vector_test.cpp
@@ -131,18 +131,18 @@ TEST_F(KnotVectorSuite, Insert) {
 }
 
 TEST_F(KnotVectorSuite, Remove) {
-  EXPECT_NO_THROW(knot_vector_.Remove(k1_0Minus_));
+  EXPECT_EQ(knot_vector_.Remove(k1_0Minus_), Multiplicity{});
   EXPECT_EQ(knot_vector_, KnotVector(knots_));
-  EXPECT_NO_THROW(knot_vector_.Remove(k1_0_));
+  EXPECT_EQ(knot_vector_.Remove(k1_0_), kMultiplicity1_);
   ASSERT_NO_THROW(knots_.erase(knots_.begin() + 8));
   EXPECT_EQ(knot_vector_, KnotVector(knots_));
-  EXPECT_NO_THROW(knot_vector_.Remove(k1_0_, kMultiplicity2_));
+  EXPECT_EQ(knot_vector_.Remove(k1_0_, kMultiplicity2_), kMultiplicity2_);
   ASSERT_NO_THROW(knots_.erase(knots_.begin() + 6, knots_.begin() + 8));
   EXPECT_EQ(knot_vector_, KnotVector(knots_));
-  EXPECT_NO_THROW(knot_vector_.Remove(k0_0_));
+  EXPECT_EQ(knot_vector_.Remove(k0_0_), kMultiplicity1_);
   ASSERT_NO_THROW(knots_.erase(knots_.begin() + 2));
   EXPECT_EQ(knot_vector_, KnotVector(knots_));
-  EXPECT_NO_THROW(knot_vector_.Remove(k0_0_, kMultiplicity2_));
+  EXPECT_EQ(knot_vector_.Remove(k0_0_, kMultiplicity2_), kMultiplicity2_);
   ASSERT_NO_THROW(knots_.erase(knots_.begin(), knots_.begin() + 2));
   EXPECT_EQ(knot_vector_, KnotVector(knots_));
 }

--- a/Tests/ParameterSpaces/parameter_space_mock.cpp
+++ b/Tests/ParameterSpaces/parameter_space_mock.cpp
@@ -74,7 +74,7 @@ ElevationInformation const kElevationInformationOnce{kIndex2, {{kOneThird, kTwoT
         kOneFourth}}}, kElevationInformationTwice{kIndex2, {kBinomialRatios, {kOneSixth, kTwoThirds, kOneSixth},
             kBinomialRatios}};
 InsertionInformation const kInsertionInformation{kIndex2, {kKnotRatiosFirst}},
-    kInsertionInformationInsertRemove{kIndex2, {kKnotRatiosSecond}}, kInsertionInformationSubdivide{kIndex2,
+    kInsertionInformationInsertRemove{kIndex2, {kKnotRatiosSecond}}, kInsertionInformationSubdivided{kIndex2,
         {kKnotRatiosFirst, kKnotRatiosSecond}}, kInsertionInformationElevateReduce{kIndex3, {kKnotRatiosSecond}},
             kInsertionInformationElevatedTwice{ScalarIndex{4}, {kKnotRatiosSecond}};
 IsGeAndLtMatcherP2<Dimension, Dimension> const &IsValidDimension = IsGeAndLt(kDimension0, Dimension{3});
@@ -418,9 +418,9 @@ void A2dParameterSpaceMock::NurbsBookExe3_8() {
                             Return(kInsertionInformation)));
   EXPECT_CALL(*this, InsertKnotMock(kDimension1, kParametricCoordinate0_5, kMultiplicity2, IsGe0_0AndLt0_5))
       .WillRepeatedly(DoAll(InvokeWithoutArgs(this, &A2dParameterSpaceMock::NurbsBookExe3_8Subdivided),
-                            Return(kInsertionInformationSubdivide)));
-  EXPECT_CALL(*this, RemoveKnotMock(kDimension0, kParametricCoordinate0_5, kMultiplicity_, IsGe0_0AndLt0_5))
-      .WillRepeatedly(Return(kInsertionInformation));
+                            Return(kInsertionInformationSubdivided)));
+  EXPECT_CALL(*this, RemoveKnotMock(kDimension1, kParametricCoordinate0_5, kMultiplicity_, IsGeAndLt(0.0, 1.0)))
+      .WillRepeatedly(Return(InsertionInformation{}));
   EXPECT_CALL(*this, ReduceDegreeMock(kDimension1, kMultiplicity_, IsGe0_0AndLt0_5))
       .WillRepeatedly(Return(InsertionInformation_{kIndex1, {kBinomialRatios}}));
 
@@ -473,12 +473,7 @@ void A2dParameterSpaceMock::NurbsBookExe3_8ElevatedTwice() {
 }
 
 void A2dParameterSpaceMock::NurbsBookExe3_8InsertRemove() {
-  knot_vectors_ = mock_knot_vectors::NurbsBookExe3_8InsertRemove();
-  degrees_ = kDegrees2_2;
-  basis_functions_ = mock_b_spline_basis_functions::Empty();
-
-  EXPECT_CALL(*this, GetNumberOfBasisFunctions()).WillRepeatedly(Return(NumberOfBasisFunctions_{kLength4, kLength4}));
-  EXPECT_CALL(*this, GetTotalNumberOfBasisFunctions()).WillRepeatedly(Return(16));
+  NurbsBookExe3_8InsertRemoveKnotVectorsDegreesBasisFunctions();
 
   EXPECT_CALL(*this, InsertKnotMock(kDimension1, kParametricCoordinate0_5, kMultiplicity_, IsGe0_0AndLt0_5))
       .WillRepeatedly(DoAll(InvokeWithoutArgs(this, &A2dParameterSpaceMock::NurbsBookExe3_8Subdivided),
@@ -509,15 +504,15 @@ void A2dParameterSpaceMock::NurbsBookExe3_8Subdivided() {
                             Return(kInsertionInformationInsertRemove)));
   EXPECT_CALL(*this, RemoveKnotMock(kDimension1, kParametricCoordinate0_5, kMultiplicity2, IsGe0_0AndLt0_5))
       .WillRepeatedly(DoAll(InvokeWithoutArgs(this, &A2dParameterSpaceMock::NurbsBookExe3_8),
-                            Return(kInsertionInformationSubdivide)));
+                            Return(kInsertionInformationSubdivided)));
 }
 
 void A2dParameterSpaceMock::NurbsBookExe3_8Unsuccessful() {
-  knot_vectors_ = mock_knot_vectors::NurbsBookExe3_8();
-  degrees_ = kDegrees2_2;
-  basis_functions_ = mock_b_spline_basis_functions::NurbsBookExe3_8();
+  NurbsBookExe3_8InsertRemoveKnotVectorsDegreesBasisFunctions();
 
-  EXPECT_CALL(*this, GetTotalNumberOfBasisFunctions()).WillRepeatedly(Return(12));
+  EXPECT_CALL(*this, RemoveKnotMock(kDimension1, kParametricCoordinate0_5, kMultiplicity_, IsGe0_0AndLt0_5))
+      .WillRepeatedly(DoAll(InvokeWithoutArgs(this, &A2dParameterSpaceMock::NurbsBookExe3_8InsertRemove),
+                            Return(kInsertionInformation)));
 }
 
 void A2dParameterSpaceMock::NurbsBookExe4_4() {
@@ -564,11 +559,6 @@ void A2dParameterSpaceMock::SquareUnitSecondOrderMaximallySmooth() {
   basis_functions_ = mock_b_spline_basis_functions::NurbsBookExe3_8();
 }
 
-void A2dParameterSpaceMock::NurbsBookExe3_8KnotVectorsDegrees() {
-  knot_vectors_ = mock_knot_vectors::NurbsBookExe3_8();
-  degrees_ = kDegrees2_2;
-}
-
 void A2dParameterSpaceMock::NurbsBookExe3_8Bezier() {
   EXPECT_CALL(*this, GetNumberOfBasisFunctions()).WillRepeatedly(Return(IndexLength{Length{5}, kLength3}));
 
@@ -609,6 +599,20 @@ void A2dParameterSpaceMock::NurbsBookExe3_8BezierElevatedTwice() {
   EXPECT_CALL(*this, ReduceDegreeMock(kDimension0, kMultiplicity2, IsGe0_0AndLt0_5))
       .WillRepeatedly(DoAll(InvokeWithoutArgs(this, &A2dParameterSpaceMock::NurbsBookExe3_8Bezier),
                             Return(kElevationInformationTwice)));
+}
+
+void A2dParameterSpaceMock::NurbsBookExe3_8InsertRemoveKnotVectorsDegreesBasisFunctions() {
+  knot_vectors_ = mock_knot_vectors::NurbsBookExe3_8InsertRemove();
+  degrees_ = kDegrees2_2;
+  basis_functions_ = mock_b_spline_basis_functions::NurbsBookExe3_8InsertRemove();
+
+  EXPECT_CALL(*this, GetNumberOfBasisFunctions()).WillRepeatedly(Return(NumberOfBasisFunctions_{kLength4, kLength4}));
+  EXPECT_CALL(*this, GetTotalNumberOfBasisFunctions()).WillRepeatedly(Return(16));
+}
+
+void A2dParameterSpaceMock::NurbsBookExe3_8KnotVectorsDegrees() {
+  knot_vectors_ = mock_knot_vectors::NurbsBookExe3_8();
+  degrees_ = kDegrees2_2;
 }
 
 void A2dParameterSpaceMock::NurbsBookExe4_4KnotVectorsDegrees() {

--- a/Tests/ParameterSpaces/parameter_space_mock.hpp
+++ b/Tests/ParameterSpaces/parameter_space_mock.hpp
@@ -94,10 +94,11 @@ class A2dParameterSpaceMock : public sources::parameter_spaces::ParameterSpace<2
   void SquareUnitSecondOrderMaximallySmooth();
 
  private:
-  void NurbsBookExe3_8KnotVectorsDegrees();
   void NurbsBookExe3_8Bezier();
   void NurbsBookExe3_8BezierElevateReduce();
   void NurbsBookExe3_8BezierElevatedTwice();
+  void NurbsBookExe3_8InsertRemoveKnotVectorsDegreesBasisFunctions();
+  void NurbsBookExe3_8KnotVectorsDegrees();
   void NurbsBookExe4_4KnotVectorsDegrees();
 };
 

--- a/Tests/ParameterSpaces/parameter_space_test.cpp
+++ b/Tests/ParameterSpaces/parameter_space_test.cpp
@@ -38,6 +38,7 @@ class ParameterSpaceSuite : public testing::Test {
   using Degrees_ = ParameterSpace_::Degrees_;
   using Derivative_ = ParameterSpace_::Derivative_;
   using ElevationInformation_ = ParameterSpace_::ElevationInformation_;
+  using InsertionInformation_ = ParameterSpace_::InsertionInformation_;
   using Knot_ = ParameterSpace_::Knot_;
   using NumberOfBasisFunctions_ = ParameterSpace_::NumberOfBasisFunctions_;
 
@@ -64,7 +65,7 @@ class ParameterSpaceSuite : public testing::Test {
               {kOneSixth_, kTwoThirds_, kOneSixth_}, kBinomialRatios_}};
   inline static ParameterSpace_::KnotRatios_ const kKnotRatiosFirst_{kOneHalf_, kOneHalf_},
                                                    kKnotRatiosSecond_{kOneHalf_};
-  inline static ParameterSpace_::InsertionInformation_ const kInsertionInformationFirst_{kIndex2_, {kKnotRatiosFirst_}},
+  inline static InsertionInformation_ const kInsertionInformationFirst_{kIndex2_, {kKnotRatiosFirst_}},
       kInsertionInformationSecond_{kIndex2_, {kKnotRatiosSecond_}}, kInsertionInformationTwice_{kIndex2_,
           {kKnotRatiosFirst_, kKnotRatiosSecond_}};
   inline static ParameterSpace_::KnotVectors_ const kKnotVectors_{mock_knot_vectors::NurbsBookExa2_2()};
@@ -180,7 +181,9 @@ TEST_F(ParameterSpaceSuite, RemoveKnotDependingOnDetermineInsertionInformationAn
   EXPECT_EQ(parameter_space_erase.RemoveKnot(kDimension1_, k0_5_, kMultiplicity2_), kInsertionInformationTwice_);
   EXPECT_EQ(parameter_space_erase, parameter_space_);
   EXPECT_EQ(parameter_space_remove.RemoveKnot(kDimension1_, k0_5_), kInsertionInformationFirst_);
-  EXPECT_EQ(parameter_space_remove, parameter_space_erase);
+  EXPECT_EQ(parameter_space_remove, parameter_space_);
+  EXPECT_EQ(parameter_space_remove.RemoveKnot(kDimension1_, k0_5_), InsertionInformation_{});
+  EXPECT_EQ(parameter_space_remove, parameter_space_);
 }
 
 TEST_F(ParameterSpaceSuite, ElevateDegreeDependingOnRecreateBasisFunctions) {

--- a/Tests/Splines/b_spline_test.cpp
+++ b/Tests/Splines/b_spline_test.cpp
@@ -157,6 +157,7 @@ TEST_F(BSplineSuite, InsertKnot) {
 }
 
 TEST_F(BSplineSuite, RemoveKnot) {
+  constexpr Multiplicity const kMultiplicity0{0};
   constexpr Multiplicity const &kMultiplicity = sources::splines::kMultiplicity;
 
   SharedPointer<ParameterSpace_> parameter_space_remove{make_shared<ParameterSpace_>()},
@@ -173,15 +174,17 @@ TEST_F(BSplineSuite, RemoveKnot) {
   BSpline_ b_spline_remove, b_spline, b_spline_unsuccessful;
   ASSERT_NO_THROW(b_spline_remove = BSpline_(parameter_space_remove, vector_space_remove));
   ASSERT_NO_THROW(b_spline = BSpline_(parameter_space, vector_space));
-  ASSERT_NO_THROW(b_spline_unsuccessful = BSpline_(parameter_space_, vector_space_unsuccessful));
+  ASSERT_NO_THROW(b_spline_unsuccessful = BSpline_(parameter_space_unsuccessful, vector_space_unsuccessful));
   EXPECT_EQ(b_spline_remove.RemoveKnot(kDimension1_, kKnot0_5_, kEpsilon_), kMultiplicity);
   EXPECT_EQ(b_spline_remove, b_spline_insert_remove_);
   EXPECT_EQ(b_spline.RemoveKnot(kDimension1_, kKnot0_5_, kEpsilon_, kMultiplicity2_), kMultiplicity2_);
   EXPECT_EQ(b_spline, b_spline_);
   EXPECT_EQ(b_spline_remove.RemoveKnot(kDimension1_, kKnot0_5_, kEpsilon_), kMultiplicity);
   EXPECT_EQ(b_spline_remove, b_spline_);
-  EXPECT_EQ(b_spline_unsuccessful.RemoveKnot(kDimension0_, kKnot0_5_, kEpsilon_), Multiplicity{});
-  EXPECT_EQ(b_spline_unsuccessful, BSpline_(parameter_space_unsuccessful, vector_space_));
+  EXPECT_EQ(b_spline_unsuccessful.RemoveKnot(kDimension1_, kKnot0_5_, kEpsilon_), kMultiplicity0);
+  EXPECT_EQ(b_spline_unsuccessful, b_spline_insert_remove_);
+  EXPECT_EQ(b_spline_remove.RemoveKnot(kDimension1_, kKnot0_5_, kEpsilon_), kMultiplicity0);
+  EXPECT_EQ(b_spline_remove, b_spline_);
 }
 
 TEST_F(BSplineSuite, ElevateDegreeDependingOnMakeBezierAndMakeBSpline) {

--- a/Tests/VectorSpaces/vector_space_mock.cpp
+++ b/Tests/VectorSpaces/vector_space_mock.cpp
@@ -664,13 +664,16 @@ void A3dVectorSpaceMock::NurbsBookExe3_8Subdivided() {
 }
 
 void A3dVectorSpaceMock::NurbsBookExe3_8Unsuccessful() {
-  constexpr Coordinate3d const kCoordinateUnremovable1_2{k6_0, k4_0, k6_0};
+  NurbsBookExe3_8InsertRemove();
 
-  NurbsBookExe3_8();
+  EXPECT_CALL(*this, OperatorSubscript(k3)).WillRepeatedly(ReturnRef(kCoordinate3_0));
+  EXPECT_CALL(*this, OperatorSubscript(k7)).WillRepeatedly(ReturnRef(kCoordinateInserted3_1));
+  EXPECT_CALL(*this, OperatorSubscript(k11)).WillRepeatedly(ReturnRef(kCoordinateInserted3_2));
+  EXPECT_CALL(*this, OperatorSubscript(k15)).WillRepeatedly(ReturnRef(kCoordinate3_2));
 
-  Expectation_ const &unremovable = EXPECT_CALL(*this, Replace(k9, kCoordinateUnremovable1_2));
-  EXPECT_CALL(*this, OperatorSubscript(k9)).After(unremovable)
-      .WillRepeatedly(ReturnRefOfCopy(kCoordinateUnremovable1_2));
+  Expectation_ const &unremovable = EXPECT_CALL(*this, Replace(k7, kCoordinate3_1));
+  EXPECT_CALL(*this, OperatorSubscript(k7)).After(unremovable)
+      .WillRepeatedly(ReturnRef(kCoordinate0_0));
 }
 
 void A3dVectorSpaceMock::NurbsBookExe4_4() {


### PR DESCRIPTION
RemoveKnot test has been improved. Instead of testing with a spline which doesn't allow for a knot removal, the test is performed on a spline for which this is possible instead. In the process, a wrong coordinate is returned by the mock vector space to ensure the knot removal algorithm catches it.